### PR TITLE
fix: align product filter presets and identifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,13 +111,13 @@ Get all subscribed rules for your scan engine, which supports YARA up to version
 response = v.get_rules_text(max_version="3.2.0", modules=['pe'])
 ```
 
-Get all subscribed rules for your `FireEyeEX`
+Get all subscribed rules for your `FireEye EX 9.0-9.11` appliance
 ```python
 
 from valhallaAPI.valhalla import ValhallaAPI
 
 v = ValhallaAPI(api_key="Your API Key")
-response = v.get_rules_text(product="FireEyeEX")
+response = v.get_rules_text(product="FireEyeEX_900_911")
 ```
 
 The following products have predefined presets

--- a/tests/test_cli_flags.py
+++ b/tests/test_cli_flags.py
@@ -7,7 +7,7 @@ import pytest
 
 import valhallaAPI.valhalla as valhalla_module
 import valhallaAPI.valhalla_cli as valhalla_cli
-from valhallaAPI.filters import ApiError
+from valhallaAPI.filters import ApiError, PRODUCT_REQUIREMENTS, get_product_requirements
 from valhallaAPI.valhalla import ValhallaAPI
 
 
@@ -179,3 +179,15 @@ def test_sigma_zip_raises_api_error(monkeypatch):
         v.get_sigma_rules_zip()
 
     assert exc.value.message == "user has no sigma rule feed access"
+
+
+def test_product_identifiers_match_filter_presets():
+    expected = [product for product in PRODUCT_REQUIREMENTS if product != "DummyTest"]
+
+    assert ValhallaAPI.PRODUCT_IDENTIFIER == expected
+    assert "DummyTest" not in ValhallaAPI.PRODUCT_IDENTIFIER
+
+
+def test_updated_product_versions():
+    assert get_product_requirements("Tanium")[0] == "4.5.0"
+    assert get_product_requirements("osquery")[0] == "4.2.0"

--- a/valhallaAPI/filters.py
+++ b/valhallaAPI/filters.py
@@ -64,7 +64,7 @@ PRODUCT_REQUIREMENTS = {
         "with_crypto": True,  # depends
     },
     "Tanium": {
-        "maximum_version": "3.7.0",
+        "maximum_version": "4.5.0",
         "supported_modules": [],
         "with_crypto": True,  # assumption
     },
@@ -81,7 +81,7 @@ PRODUCT_REQUIREMENTS = {
         "with_crypto": False,  # assumption
     },
     "osquery": {
-        "maximum_version": "3.7.1",
+        "maximum_version": "4.2.0",
         "supported_modules": ["pe", "elf", "math"],  # assumption
         "reference": "https://github.com/osql/osql/issues/11",
         "with_crypto": True,  # https://github.com/facebook/osquery/blob/experimental/tools/provision/formula/yara.rb

--- a/valhallaAPI/valhalla.py
+++ b/valhallaAPI/valhalla.py
@@ -46,10 +46,11 @@ class ValhallaAPI(object):
     GRR = "GRR"
     OSQUERY = "osquery"
 
-    PRODUCT_IDENTIFIER = ['FireEyeAX_912_915', 'FireEyeAX_900_911', 'FireEyeAX_83x_84x', 
-                          'FireEyeNX_912_915', 'FireEyeNX_900_911', 'FireEyeNX_83x' 
-                          'FireEyeEX_912_915', 'FireEyeEX_900_911', 'FireEyeEX_82x_84x', 
-                          'CarbonBlack', 'Tanium', 'Tenable', 'GRR', 'osquery']
+    # Derive the public product identifiers from the filter presets so CLI help
+    # and validation cannot drift from PRODUCT_REQUIREMENTS.
+    PRODUCT_IDENTIFIER = [
+        product for product in get_product_templates() if product != "DummyTest"
+    ]
     DEMO_KEY = "1111111111111111111111111111111111111111111111111111111111111111"
     DEFAULT_OUTPUT_FILE = 'valhalla-rules.yar'
 


### PR DESCRIPTION
## Summary
- derive `PRODUCT_IDENTIFIER` from the product preset table so CLI help and validation stay in sync
- update the YARA compatibility presets for `Tanium` to 4.5.0 and `osquery` to 4.2.0
- correct the README example to use a real FireEye EX product identifier and add tests for the preset-backed identifiers and version values

## Testing
- ./venv/bin/python -m pytest tests/test_cli_flags.py tests/test_cli_and_sigma.py